### PR TITLE
Fixed XML max_recs (=> max_records) problem

### DIFF
--- a/newinstall/config/local_records.xml
+++ b/newinstall/config/local_records.xml
@@ -29,7 +29,7 @@
 	<!--
 	Sets the maximum number of records stored per map: Lower = Faster
 	//-->
-	<max_recs>50</max_recs>
+	<max_records>50</max_records>
 
 	<!--
 	Limit the highest record that will be displayed to all.


### PR DESCRIPTION
In `plugin.local_records.php` the `MAX_RECORDS` setting from the XML `local_records.xml` is requested. However, this has not been updated yet (is still `max_recs`).

(This caused a PHP Warning on line 95 in `plugin.local_records.php`.)
