### PR TITLE
Remove closing PHP tags

### DIFF
--- a/webrequest.php
+++ b/webrequest.php
@@ -376,5 +376,3 @@ class WebRequestWorker {
 		}
 	}
 }
-
-?>


### PR DESCRIPTION
In PHP, you're not required to add a closing PHP tag at the end of the file.

This is just a PR for 1 file, but if you're ok with it, I'll do all the files.